### PR TITLE
Support of HTTP/1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "nusphere/nusoap",
-    "version": "0.9.5",
+    "version": "0.9.6",
     "type": "library",
     "description": "NuSoap Repository for Composer with some fixes",
     "authors": [

--- a/lib/changelog
+++ b/lib/changelog
@@ -393,7 +393,7 @@
 - soap_server: when getallheaders is used, massage header names
 - soap_server: use SOAPAction to determine operation when doc/lit service does not wrap parameters in an element with the method name (thanks Peter Hrastnik)
 - soap_transport_http: correctly handle multiple HTTP/1.1 100 responses for https (thanks Jan Slabon)
-- wsdl: fixed documentation for addComplexType (thanks Csintalan Ádám)
+- wsdl: fixed documentation for addComplexType (thanks Csintalan ï¿½dï¿½m)
 - wsdl: serialize array data when maxOccurs = 'unbounded' OR maxOccurs > 1 (thanks Dominique Schreckling)
 - wsdl: when serializing a string == 'false' as a boolean, set the value to false
 - wsdl: when serializing a complexType, require the PHP value supplied to be an array
@@ -441,7 +441,7 @@
 - soapclient: initialize paramArrayStr to improve proxy generation
 - soap_parser: handle PHP5 soapclient's incorrect transmission of WSDL-described SOAP encoded arrays.
 - soap_server: don't assume _SERVER['HTTPS'] is set; try HTTP_SERVER_VARS['HTTPS'] if it is not
-- soap_server: "flatten out" the parameter array to call_user_func_array (thanks André Mamitzsch)
+- soap_server: "flatten out" the parameter array to call_user_func_array (thanks Andrï¿½ Mamitzsch)
 - soap_server: make thrown exceptions conform to specs
 - wsdl: use serialize_val to serialize an array when the XSD type is soapenc:Array (JBoss/Axis does this)
 - wsdl: change formatting of serialized XML for the WSDL
@@ -646,3 +646,6 @@
 - nusoap_client: do not assign the return value of new by reference (it is deprecated) (thanks Pier-Luc Duchaine)
 - nusoap_base: replace regex function calls (ereg, eregi, split) with PCRE calls (preg_match, preg_split) (thanks Pier-Luc Duchaine)
 - nusoapmime: do not assign the return value of new by reference (it is deprecated)
+
+2015-12-03, version 0.9.6
+- soap_transport_http: added isSkippableCurlHeader() to support HTTP/1.1

--- a/lib/changelog
+++ b/lib/changelog
@@ -393,7 +393,7 @@
 - soap_server: when getallheaders is used, massage header names
 - soap_server: use SOAPAction to determine operation when doc/lit service does not wrap parameters in an element with the method name (thanks Peter Hrastnik)
 - soap_transport_http: correctly handle multiple HTTP/1.1 100 responses for https (thanks Jan Slabon)
-- wsdl: fixed documentation for addComplexType (thanks Csintalan ï¿½dï¿½m)
+- wsdl: fixed documentation for addComplexType (thanks Csintalan Ádám)
 - wsdl: serialize array data when maxOccurs = 'unbounded' OR maxOccurs > 1 (thanks Dominique Schreckling)
 - wsdl: when serializing a string == 'false' as a boolean, set the value to false
 - wsdl: when serializing a complexType, require the PHP value supplied to be an array
@@ -441,7 +441,7 @@
 - soapclient: initialize paramArrayStr to improve proxy generation
 - soap_parser: handle PHP5 soapclient's incorrect transmission of WSDL-described SOAP encoded arrays.
 - soap_server: don't assume _SERVER['HTTPS'] is set; try HTTP_SERVER_VARS['HTTPS'] if it is not
-- soap_server: "flatten out" the parameter array to call_user_func_array (thanks Andrï¿½ Mamitzsch)
+- soap_server: "flatten out" the parameter array to call_user_func_array (thanks André Mamitzsch)
 - soap_server: make thrown exceptions conform to specs
 - wsdl: use serialize_val to serialize an array when the XSD type is soapenc:Array (JBoss/Axis does this)
 - wsdl: change formatting of serialized XML for the WSDL

--- a/lib/class.soap_transport_http.php
+++ b/lib/class.soap_transport_http.php
@@ -603,13 +603,14 @@ class soap_transport_http extends nusoap_base {
 	 */
 	function isSkippableCurlHeader(&$data) {
 		$skipHeaders = array(	'HTTP/1.1 100',
-								'HTTP/1.0 301',
-								'HTTP/1.1 301',
-								'HTTP/1.0 302',
-								'HTTP/1.1 302',
-								'HTTP/1.0 401',
-								'HTTP/1.1 401',
-								'HTTP/1.0 200 Connection established');
+                                        'HTTP/1.0 301',
+                                        'HTTP/1.1 301',
+                                        'HTTP/1.0 302',
+                                        'HTTP/1.1 302',
+                                        'HTTP/1.0 401',
+                                        'HTTP/1.1 401',
+                                        'HTTP/1.0 200 Connection established',
+                                        'HTTP/1.1 200 Connection Established');
 		foreach ($skipHeaders as $hd) {
 			$prefix = substr($data, 0, strlen($hd));
 			if ($prefix == $hd) return true;

--- a/lib/class.wsdl.php
+++ b/lib/class.wsdl.php
@@ -25,6 +25,7 @@ class wsdl extends nusoap_base {
     var $currentOperation;
     var $portTypes = array();
     var $currentPortType;
+    var $currentPortOperation = '';
     var $bindings = array();
     var $currentBinding;
     var $ports = array();


### PR DESCRIPTION
In soap_transport_http the method isSkippableCurlHeader() has to be enhanced to support HTTP/1.1 checking for 'HTTP/1.1 200 Connection Established'

also removed warning of unused var currentPortOperation