### PR TITLE
Disable defect debug-call

### DIFF
--- a/lib/class.wsdl.php
+++ b/lib/class.wsdl.php
@@ -1548,7 +1548,7 @@ class wsdl extends nusoap_base {
 				$rows = sizeof($value);
 				$contents = '';
 				foreach($value as $k => $v) {
-					$this->debug("serializing array element: $k, $v of type: $typeDef[arrayType]");
+					//$this->debug("serializing array element: $k, $v of type: $typeDef[arrayType]");
 					//if (strpos($typeDef['arrayType'], ':') ) {
 					if (!in_array($typeDef['arrayType'],$this->typemap['http://www.w3.org/2001/XMLSchema'])) {
 					    $contents .= $this->serializeType('item', $typeDef['arrayType'], $v, $use);


### PR DESCRIPTION
Hi,

this little pull request disable a single debug-method-call. It throws an "array to string conversion"-exception, if an own complexType with arrays was used.

For examples, please have a look to StackOverflow:
https://stackoverflow.com/questions/22482881/notice-array-to-string-conversion-using-nusoap
https://stackoverflow.com/questions/18779953/how-to-deal-with-array-complextype-in-nusoap